### PR TITLE
Fixed infinite stack clearing back, when we call navigateUp

### DIFF
--- a/app/src/main/java/com/paywings/oauth/android/sample_app/ui/nav/NavRoute.kt
+++ b/app/src/main/java/com/paywings/oauth/android/sample_app/ui/nav/NavRoute.kt
@@ -91,6 +91,7 @@ interface NavRoute<T : RouteNavigator> {
             }
             is NavigationState.NavigateUp -> {
                 navHostController.navigateUp()
+                onNavigated(navigationState)
             }
             is NavigationState.Idle -> {
             }


### PR DESCRIPTION
In the current view, it is impossible to call the event - click back. Fixed multiple call to navigateUp